### PR TITLE
changed abstract document visibility to protected

### DIFF
--- a/Document/AbstractCategoryDocument.php
+++ b/Document/AbstractCategoryDocument.php
@@ -31,66 +31,66 @@ abstract class AbstractCategoryDocument implements DocumentInterface
      *
      * @ES\Property(type="string", name="sort")
      */
-    private $sort;
+    protected $sort;
 
     /**
      * @var bool
      *
      * @ES\Property(type="boolean", name="is_active")
      */
-    private $active;
+    protected $active;
 
     /**
      * @var string
      *
      * @ES\Property(type="string", name="parent_id")
      */
-    private $parentId;
+    protected $parentId;
 
     /**
      * @var int
      *
      * @ES\Property(type="integer", name="level")
      */
-    private $level;
+    protected $level;
 
     /**
      * @var string
      *
      * @ES\Property(type="string", name="title", index="not_analyzed")
      */
-    private $title;
+    protected $title;
 
     /**
      * @var bool
      *
      * @ES\Property(type="boolean", name="is_hidden")
      */
-    private $hidden;
+    protected $hidden;
 
     /**
      * @var int
      *
      * @ES\Property(type="integer", name="left")
      */
-    private $left;
+    protected $left;
 
     /**
      * @var int
      *
      * @ES\Property(type="integer", name="right")
      */
-    private $right;
+    protected $right;
 
     /**
      * @var bool
      */
-    private $expanded;
+    protected $expanded;
 
     /**
      * @var bool
      */
-    private $current;
+    protected $current;
 
     /**
      * @var array
@@ -100,7 +100,7 @@ abstract class AbstractCategoryDocument implements DocumentInterface
     /**
      * @var AbstractCategoryDocument[]|\Iterator
      */
-    private $children;
+    protected $children;
 
     /**
      * Tests if category has any children.

--- a/Document/AbstractContentDocument.php
+++ b/Document/AbstractContentDocument.php
@@ -31,21 +31,21 @@ abstract class AbstractContentDocument implements DocumentInterface
      *
      * @ES\Property(type="string", name="slug", index="not_analyzed")
      */
-    private $slug;
+    protected $slug;
 
     /**
      * @var string
      *
      * @ES\Property(type="string", name="title", index="not_analyzed")
      */
-    private $title;
+    protected $title;
 
     /**
      * @var string
      *
      * @ES\Property(type="string", name="content")
      */
-    private $content;
+    protected $content;
 
     /**
      * @return string

--- a/Document/AbstractProductDocument.php
+++ b/Document/AbstractProductDocument.php
@@ -29,35 +29,35 @@ abstract class AbstractProductDocument implements DocumentInterface
      *
      * @ES\Property(type="string", name="title", fields={@ES\MultiField(name="raw", type="string")})
      */
-    private $title;
+    protected $title;
 
     /**
      * @var string
      *
      * @ES\Property(type="string", name="description")
      */
-    private $description;
+    protected $description;
 
     /**
      * @var string
      *
      * @ES\Property(type="string", name="long_description")
      */
-    private $longDescription;
+    protected $longDescription;
 
     /**
      * @var string
      *
      * @ES\Property(type="string", name="sku")
      */
-    private $sku;
+    protected $sku;
 
     /**
      * @var float
      *
      * @ES\Property(type="float", name="price")
      */
-    private $price;
+    protected $price;
 
     /**
      * @return string


### PR DESCRIPTION
Private properties could not be seen when extended.

[FOSUserBundle](https://github.com/FriendsOfSymfony/FOSUserBundle/blob/master/Model/User.php) also uses protected properties for their entities which are also ment to overwrite.

User can put private properties in their documents but we must keep them only protected in abstract documents.